### PR TITLE
disabled_denorm_refactor

### DIFF
--- a/custom/src/Console/Command/TeamSetPrune/TeamSetPruneBackupCommand.php
+++ b/custom/src/Console/Command/TeamSetPrune/TeamSetPruneBackupCommand.php
@@ -20,11 +20,13 @@ class TeamSetPruneBackupCommand extends TeamSetPruneCommand implements InstanceM
     {
         $this
             ->setName('teamset:backup')
-            ->setDescription('Backs up the current denorm table and the team_sets, team_sets_teams, and team_sets_modules tables.');
+            ->setDescription('Backs up the team_sets related tables.');
         $this->setHelp("
             You don't need to run this command before you run teamset:prune.
             This command only backs up the team set tables. This is performed automatically when you run teamset:prune.
             But if you want backups of these tables for some other purpose, you can use this command to do so easily.
+            It will back up these tables: team_sets, team_sets_teams, team_sets_modules, and the active denorm table
+            (team_sets_users_[1|2])if denormalization is enabled.
             ");
     }
 

--- a/custom/src/Console/Command/TeamSetPrune/TeamSetPruneCommand.php
+++ b/custom/src/Console/Command/TeamSetPrune/TeamSetPruneCommand.php
@@ -29,19 +29,17 @@ abstract class TeamSetPruneCommand extends Command implements InstanceModeInterf
     {
         $state = Container::getInstance()->get(State::class);
 
-        if (!$state->isEnabled()) {
-            $exception = new \Exception("Team Security Denormalization is not enabled!. Cannot prune team sets in an instance where team security is disabled.");
-            throw $exception;
-        }
+        if ($state->isEnabled()) {
 
-        if (!$state->isAvailable()) {
-            $exception = new \Exception("The Team Security Denormalization table is not available. It may not exist. You can create it with the team-security:rebuild command.");
-            throw $exception;
-        }
+            if (!$state->isAvailable()) {
+                $exception = new \Exception("The Team Security Denormalization table is not available. It may not exist. You can create it with the team-security:rebuild command.");
+                throw $exception;
+            }
 
-        if ($state->isRebuildRunning()) {
-            $exception = new \Exception("The Team Security Denormalization table is currently being rebuilt. We cannot prune until the rebuild is complete");
-            throw $exception;
+            if ($state->isRebuildRunning()) {
+                $exception = new \Exception("The Team Security Denormalization table is currently being rebuilt. We cannot prune until the rebuild is complete");
+                throw $exception;
+            }
         }
         return true;
     }

--- a/custom/src/Console/Command/TeamSetPrune/TeamSetPrunePruneCommand.php
+++ b/custom/src/Console/Command/TeamSetPrune/TeamSetPrunePruneCommand.php
@@ -19,13 +19,13 @@ class TeamSetPrunePruneCommand extends TeamSetPruneCommand implements InstanceMo
     {
         $this
             ->setName('teamset:prune')
-            ->setDescription('Prune the denorm table and all team set tables of unused team sets. Original tables will be backed up automatically. DO NOT USE while users are logged into the system!')
+            ->setDescription('Prune all team set tables of unused team sets. Original tables will be backed up automatically. DO NOT USE while users are logged into the system!')
             ->setHelp("
             
                 NOTE: You should only run this during a planned outage. 
                 
-                Pruning the denorm table means
-                1) Backing up the denorm table, and the team_sets, team_sets_teams and team_sets_modules tables.
+                Pruning the team sets tables means
+                1) Backing up the denormalization table (if denorm is enabled), and the team_sets, team_sets_teams and team_sets_modules tables.
                    Backup tables start with 'tsp_' and end with a datetime stamp, '_MMDDHHMM'
                 2) Truncating the original tables.
                 3) Copying the active team sets out of the backup tables and into the truncated original tables, 

--- a/custom/src/Console/Command/TeamSetPrune/TeamSetPruneScanCommand.php
+++ b/custom/src/Console/Command/TeamSetPrune/TeamSetPruneScanCommand.php
@@ -19,10 +19,9 @@ class TeamSetPruneScanCommand extends TeamSetPruneCommand implements InstanceMod
     {
         $this
             ->setName('teamset:scan')
-            ->setDescription('Scan the denormalization table for unused team sets entries and report the number found.')
+            ->setDescription('Scan all module tables for unused team sets and report the number found.')
             ->setHelp("
-            Makes no changes, just reports how many unused team sets are in the denorm table and how
-            many records those unused team sets represent
+            Makes no changes, just reports how many unused team sets are in the database.
             ");
 
     }


### PR DESCRIPTION
Previously the team set pruner was designed to work only with an instance that had enabled denormalization. However, this isn't even the default beahvior for sugar, so assuming it's enabled isn't safe.

I chagned all of the SQL queries that depended on the denorm table use the team_sets table instead. The data that we need is actually team set id's, so using this table instead of the active denorm table not only makes more sense, but should also be more performant. It wouldn't have worked for JPMC because they managed to delete a huge, more-or-less random chunk from their team_sets table.

I also changed the backup and restore methods to only work with the denorm table if denormalization is enabled.

I removed the preflight check that would stop the prune if denormalization wasn't enabled. It still checks for the active table being available and the system not being in a rebuild state.

I changed the help messages in the commands to reflect that the pruner was no longer working off of the denorm table.